### PR TITLE
Sensor-poll functionality 

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,14 +25,6 @@ def ping():
     terminalSerObj, response = sdec.command_list[userCommand](userArgs, terminalSerObj)
     return response
 
-@app.route("/ping")
-def ping():
-    terminalSerObj = sdec.terminalData()
-    userCommand = "ping"
-    userArgs = ["-t"]
-    terminalSerObj, response = sdec.command_list[userCommand](userArgs, terminalSerObj)
-    return response
-
 @app.route("/comports-l", methods=['GET'])
 def comports():
     terminalSerObj = sdec.terminalData()
@@ -41,7 +33,7 @@ def comports():
     terminalSerObj, ports = sdec.command_list[userCommand](userArgs, terminalSerObj)
     return ports
 
-@app.route("/comports-d")
+@app.route("/comports-d", methods=['GET'])
 def comports_disconnect():
     terminalSerObj = sdec.terminalData()
     userCommand = "comports"

--- a/app.py
+++ b/app.py
@@ -1,11 +1,18 @@
 # save this as app.py
 from flask import Flask
 
+from sdec import sdec
+
+terminalSerObj = sdec.terminalData()
+
 app = Flask(__name__)
 
-@app.route("/")
-def hello():
-    return "Hello, World!"
+@app.route("/comport-l")
+def comport():
+    userCommand = "comport"
+    userArgs = "-l"
+    terminalSerObj, ports = sdec.command_list[userCommand](userArgs, terminalSerObj)
+    return ports
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -1,12 +1,14 @@
 # General
+import threading
 import time
 import os
 import sys
 import datetime
 import math
+import json
 
 # save this as app.py
-from flask import Flask, request
+from flask import Flask, request, Response
 from flask_cors import CORS
 # Setup path
 sys.path.insert(0, './sdec')
@@ -17,9 +19,13 @@ import sdec
 app = Flask(__name__)
 CORS(app)
 
+# Global terminalSerObj
+terminalSerObj = sdec.terminalData()
+is_polling = False
+
 @app.route("/ping")
 def ping():
-    terminalSerObj = sdec.terminalData()
+    global terminalSerObj
     userCommand = "ping"
     userArgs = ["-t"]
     terminalSerObj, response = sdec.command_list[userCommand](userArgs, terminalSerObj)
@@ -27,7 +33,7 @@ def ping():
 
 @app.route("/comports-l", methods=['GET'])
 def comports():
-    terminalSerObj = sdec.terminalData()
+    global terminalSerObj
     userCommand = "comports"
     userArgs = ["-l"]
     terminalSerObj, ports = sdec.command_list[userCommand](userArgs, terminalSerObj)
@@ -35,7 +41,7 @@ def comports():
 
 @app.route("/comports-d", methods=['GET'])
 def comports_disconnect():
-    terminalSerObj = sdec.terminalData()
+    global terminalSerObj
     userCommand = "comports"
     userArgs = ["-d"]
     terminalSerObj, confirmation = sdec.command_list[userCommand](userArgs, terminalSerObj)
@@ -44,13 +50,38 @@ def comports_disconnect():
 @app.route("/connect-p", methods=['POST'])
 def connect():
     if request.method == "POST":
+        global terminalSerObj
         com_port = request.get_json()["comport"]
-        terminalSerObj = sdec.terminalData()
         userCommand = "connect"
         userArgs = ["-p",com_port]
         terminalSerObj, status = sdec.command_list[userCommand](userArgs, terminalSerObj)
         return status
     return "invalid"
+
+@app.route("/sensor-dump", methods=['GET'])
+def sensor_dump():
+    global terminalSerObj
+    userCommand = "sensor"
+    userArgs = ["dump"]
+    terminalSerObj, data_dump = sdec.command_list[userCommand](userArgs, terminalSerObj)
+    return data_dump
+
+def sensor_poll_dump(dumps):
+    global terminalSerObj
+    userCommand = "sensor"
+    userArgs = ["dump"]
+
+    for i in range(0, dumps):
+        terminalSerObj, data_dump = sdec.command_list[userCommand](userArgs, terminalSerObj)
+        print("yield: {0}".format(i + 1))
+        yield f"data: {json.dumps(data_dump)}\n\n"
+        time.sleep(0.1)
+
+@app.route("/sensor-poll", methods=['GET'])
+def sensor_poll():
+    # \?time=<time>
+    time = int(request.args.get('time', 100)) # Defaults to 100 sensor-dumps
+    return Response(sensor_poll_dump(time), mimetype='text/event-stream')
 
 @app.route("/")
 def default():

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import math
 
 # save this as app.py
 from flask import Flask
-
+from flask_cors import CORS
 # Setup path
 sys.path.insert(0, './sdec')
 
@@ -15,6 +15,7 @@ sys.path.insert(0, './sdec')
 import sdec
 
 app = Flask(__name__)
+CORS(app)
 
 @app.route("/comports-l")
 def comports():

--- a/app.py
+++ b/app.py
@@ -17,6 +17,22 @@ import sdec
 app = Flask(__name__)
 CORS(app)
 
+@app.route("/ping")
+def ping():
+    terminalSerObj = sdec.terminalData()
+    userCommand = "ping"
+    userArgs = ["-t"]
+    terminalSerObj, response = sdec.command_list[userCommand](userArgs, terminalSerObj)
+    return response
+
+@app.route("/ping")
+def ping():
+    terminalSerObj = sdec.terminalData()
+    userCommand = "ping"
+    userArgs = ["-t"]
+    terminalSerObj, response = sdec.command_list[userCommand](userArgs, terminalSerObj)
+    return response
+
 @app.route("/comports-l", methods=['GET'])
 def comports():
     terminalSerObj = sdec.terminalData()
@@ -24,6 +40,14 @@ def comports():
     userArgs = ["-l"]
     terminalSerObj, ports = sdec.command_list[userCommand](userArgs, terminalSerObj)
     return ports
+
+@app.route("/comports-d")
+def comports_disconnect():
+    terminalSerObj = sdec.terminalData()
+    userCommand = "comports"
+    userArgs = ["-d"]
+    terminalSerObj, confirmation = sdec.command_list[userCommand](userArgs, terminalSerObj)
+    return confirmation
 
 @app.route("/connect-p", methods=['POST'])
 def connect():
@@ -35,10 +59,6 @@ def connect():
         terminalSerObj, status = sdec.command_list[userCommand](userArgs, terminalSerObj)
         return status
     return "invalid"
-
-# TODO: Impl comports -d (Disconnect active port)
-#       Impl "ping"       : commands.ping
-
 
 @app.route("/")
 def default():

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import datetime
 import math
 
 # save this as app.py
-from flask import Flask
+from flask import Flask, request
 from flask_cors import CORS
 # Setup path
 sys.path.insert(0, './sdec')
@@ -17,7 +17,7 @@ import sdec
 app = Flask(__name__)
 CORS(app)
 
-@app.route("/comports-l")
+@app.route("/comports-l", methods=['GET'])
 def comports():
     terminalSerObj = sdec.terminalData()
     userCommand = "comports"
@@ -25,13 +25,16 @@ def comports():
     terminalSerObj, ports = sdec.command_list[userCommand](userArgs, terminalSerObj)
     return ports
 
-@app.route("/connect-p")
+@app.route("/connect-p", methods=['POST'])
 def connect():
-    terminalSerObj = sdec.terminalData()
-    userCommand = "connect"
-    userArgs = ["-p","/dev/ttyUSB0"]
-    terminalSerObj, ports = sdec.command_list[userCommand](userArgs, terminalSerObj)
-    return
+    if request.method == "POST":
+        com_port = request.get_json()["comport"]
+        terminalSerObj = sdec.terminalData()
+        userCommand = "connect"
+        userArgs = ["-p",com_port]
+        terminalSerObj, status = sdec.command_list[userCommand](userArgs, terminalSerObj)
+        return status
+    return "invalid"
 
 # TODO: Impl comports -d (Disconnect active port)
 #       Impl "ping"       : commands.ping


### PR DESCRIPTION
This includes the functionality for sensor-poll to properly request sensor dump from the flight computer to provide a constant stream of data, replicating the original sensor-poll from sdec. Changes to sdec are to include the returns needed for sdec-api to get the data and for sdec to handle when the returns are just the terminalSerObj or include data for sdec-api. 