### PR TITLE
Add support for multiple clients

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,9 +40,9 @@ def ping():
         data = serial_connection.read()
 
         if data == b"\x05" or data == b'\x10': #should not hardcode
-            return "Ping response received"
+            return Response("Ping response received", status=200)
         else:
-            return "Ping failed"
+            return Response("Ping failed", status=400)
         
 @app.route("/comports")
 def comports():
@@ -74,7 +74,7 @@ def connect():
             else:
                 serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
 
-                if not serial_connection.open_comport(): return "Failed to open comport"
+                if not serial_connection.open_comport(): return Response("Failed to open comport", status=400)
 
                 # send connect opcode
                 serial_connection.connect()
@@ -101,8 +101,8 @@ def connect():
 @app.route("/disconnect")
 def disconnect():
     with serial_lock():
-        if not serial_connection.close_comport(): return "Failed to close comport"
-        return "Disconnected"
+        if not serial_connection.close_comport(): return Response("Failed to close comport", status=400)
+        return Response("Disconnected", status=200)
 
 @app.route("/wireless-stats")
 def wireless_stats():
@@ -120,7 +120,7 @@ def dashboard_dump():
     
     elif request.method == "POST":
         data = request.get_json(silent=True)
-        if not data: return "Missing POST JSON data"
+        if not data: return Response("Missing POST JSON data", status=400)
 
         start = data.get("start")
         stop = data.get("stop")

--- a/app.py
+++ b/app.py
@@ -29,9 +29,11 @@ CORS(app)
 # Globals for polling dashboard dump
 stop_event = threading.Event()
 telemetry_obj = Telemetry()
-dashboard_dump_thread = threading.Thread(target=poll_dashboard_dump, 
-                                         args=(serial_connection, stop_event, telemetry_obj), 
-                                         daemon=True)
+dashboard_dump_thread = threading.Thread(
+    target=poll_dashboard_dump,
+    args=(serial_connection, stop_event, telemetry_obj),
+    daemon=True
+)
 
 @app.route("/ping")
 def ping():
@@ -115,6 +117,7 @@ def wireless_stats():
     
 @app.route("/dashboard-dump", methods=["GET", "POST"])
 def dashboard_dump():
+    global dashboard_dump_thread
     if request.method == "GET":
         return jsonify(telemetry_obj.get_latest_dashboard_dump())
     
@@ -131,7 +134,6 @@ def dashboard_dump():
             if dashboard_dump_thread.is_alive(): # Protective case
                 return Response("Polling was already running", status=200)
             else:
-                global dashboard_dump_thread
                 stop_event.clear()
                 dashboard_dump_thread = threading.Thread(
                     target=poll_dashboard_dump,

--- a/app.py
+++ b/app.py
@@ -106,7 +106,6 @@ def disconnect():
         if not serial_connection.close_comport(): return "Failed to close comport"
         return "Disconnected"
 
-# Stub, will be implemented for SDEC v2.1.0
 @app.route("/wireless-stats")
 def wireless_stats():
     if serial_connection.target is None:
@@ -128,17 +127,23 @@ def dashboard_dump():
         start = data.get("start")
         stop = data.get("stop")
 
-        if bool(start) == bool(stop): return "Only start or stop can be set"
+        if bool(start) == bool(stop): return Response("Only start XOR stop can be set", status=400)
 
         if start:
-            stop_event.clear()
-            dashboard_dump_thread.start()
-            return "dashboard-dump poll started"
+            if dashboard_dump_thread.is_alive(): # Protective case
+                return Response("Polling was already running", status=204)
+            else:
+                stop_event.clear()
+                dashboard_dump_thread.start()
+                return Response("Dashboard-dump poll started", status=200)
         elif stop:
-            stop_event.set()
-            return "dashboard-dump poll stopped"
+            if not dashboard_dump_thread.is_alive(): # Protective case
+                return Response("Polling was already stopped", status=204)
+            else:
+                stop_event.set()
+                return Response("Dashboard-dump poll stopped", status=200)
     
-    return "Invalid Method"
+    return Response("Invalid condition", status=400)
     
 @app.route("/sensor-dump")
 def sensor_dump():

--- a/app.py
+++ b/app.py
@@ -131,14 +131,14 @@ def dashboard_dump():
 
         if start:
             if dashboard_dump_thread.is_alive(): # Protective case
-                return Response("Polling was already running", status=204)
+                return Response("Polling was already running", status=200)
             else:
                 stop_event.clear()
                 dashboard_dump_thread.start()
                 return Response("Dashboard-dump poll started", status=200)
         elif stop:
             if not dashboard_dump_thread.is_alive(): # Protective case
-                return Response("Polling was already stopped", status=204)
+                return Response("Polling was already stopped", status=200)
             else:
                 stop_event.set()
                 return Response("Dashboard-dump poll stopped", status=200)

--- a/app.py
+++ b/app.py
@@ -50,6 +50,8 @@ def comports():
         
 @app.route("/connect", methods=["POST"])
 def connect():
+    # Set up handling for request
+    connected = False
     data = request.get_json(silent=True)
     if not data: return "Missing POST JSON data"
 
@@ -63,17 +65,31 @@ def connect():
     except (TypeError, ValueError):
         return "Invalid timeout value"
     
-    try:
-        serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
+    # Check for an existing connection
+    if serial_connection.target is not None:
+        connected = True
+    
+    # Initialize a new connection if one does not exist
+    if not connected:
+        try:
+            with serial_lock():
+                serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
 
-        if not serial_connection.open_comport(): return "Failed to open comport"
+                if not serial_connection.open_comport(): return "Failed to open comport"
 
-        # send connect opcode
-        serial_connection.connect()
+                # send connect opcode
+                serial_connection.connect()
 
-        if( serial_connection.target is None ):
-            return Response("Serial connection failed.", status=400)
-
+                if( serial_connection.target is None ):
+                    return Response("Serial connection failed.", status=400)
+                else:
+                    connected = True
+        
+        except SerialException as e:
+            return Response("Serial connection error", status=400)
+    
+    # Return connection status
+    if connected and serial_connection.target is not None:
         return jsonify({
             "controller": {
                 "firmware": serial_connection.target.firmware.name,
@@ -81,14 +97,14 @@ def connect():
             },
             "status": "connected"
         })
-    
-    except SerialException as e:
-        return Response("Serial connection error", status=400)
+    else: # Shouldn't get here -- protective case
+        return Response("Serial connection failed (server-side error).", status=500)
     
 @app.route("/disconnect")
 def disconnect():
-    if not serial_connection.close_comport(): return "Failed to close comport"
-    return "Disconnected"
+    with serial_lock():
+        if not serial_connection.close_comport(): return "Failed to close comport"
+        return "Disconnected"
 
 # Stub, will be implemented for SDEC v2.1.0
 @app.route("/wireless-stats")

--- a/app.py
+++ b/app.py
@@ -53,26 +53,25 @@ def connect():
     # Set up handling for request
     connected = False
     data = request.get_json(silent=True)
-    if not data: return "Missing POST JSON data"
+    if not data: return Response("Missing POST JSON data", status=400)
 
     name = data.get("comport")
     timeout = data.get("timeout", 5)
 
-    if not name: return "Missing 'comport' field"
+    if not name: return Response("Missing 'comport' field", status=400)
 
     try:
         timeout = int(timeout)
     except (TypeError, ValueError):
-        return "Invalid timeout value"
-    
-    # Check for an existing connection
-    if serial_connection.target is not None:
-        connected = True
+        return Response("Invalid timeout value", status=400)
     
     # Initialize a new connection if one does not exist
-    if not connected:
-        try:
-            with serial_lock():
+    try:
+        with serial_lock():
+            # This check can cause a race condition. It needs to be in the lock.
+            if serial_connection.target is not None:
+                connected = True
+            else:
                 serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
 
                 if not serial_connection.open_comport(): return "Failed to open comport"
@@ -84,9 +83,8 @@ def connect():
                     return Response("Serial connection failed.", status=400)
                 else:
                     connected = True
-        
-        except SerialException as e:
-            return Response("Serial connection error", status=400)
+    except SerialException as e:
+        return Response("Serial connection error", status=400)
     
     # Return connection status
     if connected and serial_connection.target is not None:
@@ -133,7 +131,13 @@ def dashboard_dump():
             if dashboard_dump_thread.is_alive(): # Protective case
                 return Response("Polling was already running", status=200)
             else:
+                global dashboard_dump_thread
                 stop_event.clear()
+                dashboard_dump_thread = threading.Thread(
+                    target=poll_dashboard_dump,
+                    args=(serial_connection, stop_event, telemetry_obj),
+                    daemon=True
+                )
                 dashboard_dump_thread.start()
                 return Response("Dashboard-dump poll started", status=200)
         elif stop:


### PR DESCRIPTION
Closes #14

This feature will be needed for the NLFS (new liquid feed system) concept, so I'd like to implement it early and have multi-client operations be a supported/tested feature long before we need this for a test.

Please play extra close attention to the use of the serial_lock. Misuse can result in a deadlock, which would be catastrophic to test operations. This should be reserved every time a hardware interaction takes place, and failure to do so can take the whole system down.

This implementation should make no change to the client-server contract. Dashboard should ideally be able to run with multiple clients attached to one API. However, we have fixed our HTTP responses to always return 200 OK if a request succeeds and something else if it does not. @favillat, you may want to consider accounting for this, particularly in the 204 and 400 cases.

I will run an integration test with multiple dashboards when I get a second. Opening the PR before that's ready so I can have coderabbit or something review this for synchronization issues.

Leo & Ethan, I'm not sure how much API exposure you've had yet so I don't know if you'd be the best reviewers here. Tagging @favillat since his project interfaces with the API and he's probably the best candidate here.