### PR TITLE
Rework the /comports route

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,9 +40,9 @@ def ping():
         data = serial_connection.read()
 
         if data == b"\x05" or data == b'\x10': #should not hardcode
-            return "Ping response received"
+            return Response("Ping response received", status=200)
         else:
-            return "Ping failed"
+            return Response("Ping failed", status=400)
         
 @app.route("/comports")
 def comports():
@@ -74,7 +74,7 @@ def connect():
             else:
                 serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
 
-                if not serial_connection.open_comport(): return "Failed to open comport"
+                if not serial_connection.open_comport(): return Response("Failed to open comport", status=400)
 
                 # send connect opcode
                 serial_connection.connect()
@@ -101,8 +101,8 @@ def connect():
 @app.route("/disconnect")
 def disconnect():
     with serial_lock():
-        if not serial_connection.close_comport(): return "Failed to close comport"
-        return "Disconnected"
+        if not serial_connection.close_comport(): return Response("Failed to close comport", status=400)
+        return Response("Disconnected", status=200)
 
 @app.route("/wireless-stats")
 def wireless_stats():
@@ -120,7 +120,7 @@ def dashboard_dump():
     
     elif request.method == "POST":
         data = request.get_json(silent=True)
-        if not data: return "Missing POST JSON data"
+        if not data: return Response("Missing POST JSON data", status=400)
 
         start = data.get("start")
         stop = data.get("stop")

--- a/app.py
+++ b/app.py
@@ -29,9 +29,11 @@ CORS(app)
 # Globals for polling dashboard dump
 stop_event = threading.Event()
 telemetry_obj = Telemetry()
-dashboard_dump_thread = threading.Thread(target=poll_dashboard_dump, 
-                                         args=(serial_connection, stop_event, telemetry_obj), 
-                                         daemon=True)
+dashboard_dump_thread = threading.Thread(
+    target=poll_dashboard_dump,
+    args=(serial_connection, stop_event, telemetry_obj),
+    daemon=True
+)
 
 @app.route("/ping")
 def ping():
@@ -115,6 +117,7 @@ def wireless_stats():
     
 @app.route("/dashboard-dump", methods=["GET", "POST"])
 def dashboard_dump():
+    global dashboard_dump_thread
     if request.method == "GET":
         return jsonify(telemetry_obj.get_latest_dashboard_dump())
     
@@ -131,7 +134,6 @@ def dashboard_dump():
             if dashboard_dump_thread.is_alive(): # Protective case
                 return Response("Polling was already running", status=200)
             else:
-                global dashboard_dump_thread
                 stop_event.clear()
                 dashboard_dump_thread = threading.Thread(
                     target=poll_dashboard_dump,

--- a/app.py
+++ b/app.py
@@ -106,7 +106,6 @@ def disconnect():
         if not serial_connection.close_comport(): return "Failed to close comport"
         return "Disconnected"
 
-# Stub, will be implemented for SDEC v2.1.0
 @app.route("/wireless-stats")
 def wireless_stats():
     if serial_connection.target is None:
@@ -128,17 +127,23 @@ def dashboard_dump():
         start = data.get("start")
         stop = data.get("stop")
 
-        if bool(start) == bool(stop): return "Only start or stop can be set"
+        if bool(start) == bool(stop): return Response("Only start XOR stop can be set", status=400)
 
         if start:
-            stop_event.clear()
-            dashboard_dump_thread.start()
-            return "dashboard-dump poll started"
+            if dashboard_dump_thread.is_alive(): # Protective case
+                return Response("Polling was already running", status=204)
+            else:
+                stop_event.clear()
+                dashboard_dump_thread.start()
+                return Response("Dashboard-dump poll started", status=200)
         elif stop:
-            stop_event.set()
-            return "dashboard-dump poll stopped"
+            if not dashboard_dump_thread.is_alive(): # Protective case
+                return Response("Polling was already stopped", status=204)
+            else:
+                stop_event.set()
+                return Response("Dashboard-dump poll stopped", status=200)
     
-    return "Invalid Method"
+    return Response("Invalid condition", status=400)
     
 @app.route("/sensor-dump")
 def sensor_dump():

--- a/app.py
+++ b/app.py
@@ -51,7 +51,6 @@ def comports():
             comports = serial_connection.available_comports()
 
         if comports:
-            print(str(comports))
             return jsonify(comports), 200
         else:
             return Response("No ports present.", 204)

--- a/app.py
+++ b/app.py
@@ -131,14 +131,14 @@ def dashboard_dump():
 
         if start:
             if dashboard_dump_thread.is_alive(): # Protective case
-                return Response("Polling was already running", status=204)
+                return Response("Polling was already running", status=200)
             else:
                 stop_event.clear()
                 dashboard_dump_thread.start()
                 return Response("Dashboard-dump poll started", status=200)
         elif stop:
             if not dashboard_dump_thread.is_alive(): # Protective case
-                return Response("Polling was already stopped", status=204)
+                return Response("Polling was already stopped", status=200)
             else:
                 stop_event.set()
                 return Response("Dashboard-dump poll stopped", status=200)

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import threading
 
 from flask import Flask, request, Response, jsonify
 from flask_cors import CORS
-from hardware import serial_connection, sensor_sentry, serial_lock, firmware # Objects from hardware.py
+from hardware import serial_connection, sensor_sentry, serial_lock, background_lifecycle_lock, firmware # Objects from hardware.py
 from serial import SerialException
 from threads import poll_dashboard_dump
 from typing import List, Dict
@@ -164,24 +164,25 @@ def dashboard_dump():
 
         if bool(start) == bool(stop): return Response("Only start XOR stop can be set", status=400)
 
-        if start:
-            if dashboard_dump_thread.is_alive(): # Protective case
-                return Response("Polling was already running", status=200)
-            else:
-                stop_event.clear()
-                dashboard_dump_thread = threading.Thread(
-                    target=poll_dashboard_dump,
-                    args=(serial_connection, stop_event, telemetry_obj),
-                    daemon=True
-                )
-                dashboard_dump_thread.start()
-                return Response("Dashboard-dump poll started", status=200)
-        elif stop:
-            if not dashboard_dump_thread.is_alive(): # Protective case
-                return Response("Polling was already stopped", status=200)
-            else:
-                stop_event.set()
-                return Response("Dashboard-dump poll stopped", status=200)
+        with background_lifecycle_lock():
+            if start:
+                if dashboard_dump_thread.is_alive(): # Protective case
+                    return Response("Polling was already running", status=200)
+                else:
+                    stop_event.clear()
+                    dashboard_dump_thread = threading.Thread(
+                        target=poll_dashboard_dump,
+                        args=(serial_connection, stop_event, telemetry_obj),
+                        daemon=True
+                    )
+                    dashboard_dump_thread.start()
+                    return Response("Dashboard-dump poll started", status=200)
+            elif stop:
+                if not dashboard_dump_thread.is_alive(): # Protective case
+                    return Response("Polling was already stopped", status=200)
+                else:
+                    stop_event.set()
+                    return Response("Dashboard-dump poll stopped", status=200)
     
     return Response("Invalid condition", status=400)
     

--- a/app.py
+++ b/app.py
@@ -53,6 +53,12 @@ def comports():
             comports = serial_connection.available_comports()
 
         if comports:
+            # If there's an existing connection, 
+            # prune the other comports from the 
+            # list since the API only supports one at a time
+            port = serial_connection.get_port_name()
+            if port:
+                comports = { port: comports[port] }
             return jsonify(comports), 200
         else:
             return Response("No ports present.", 204)
@@ -97,6 +103,7 @@ def connect():
             if serial_connection.target is not None:
                 connected = True
             else:
+                # Initialize and connect in this block
                 serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
 
                 if not serial_connection.open_comport(): return Response("Failed to open comport", status=400)
@@ -113,6 +120,10 @@ def connect():
     
     # Return connection status
     if connected and serial_connection.target is not None:
+        # Robustness: Check if the requested port is not the open one
+        if serial_connection.get_port_name() != name:
+            return Response("Another connection is already open", 400)
+        
         return jsonify({
             "controller": {
                 "firmware": serial_connection.target.firmware.name,

--- a/app.py
+++ b/app.py
@@ -46,7 +46,31 @@ def ping():
         
 @app.route("/comports")
 def comports():
-    return serial_connection.available_comports()
+    try:
+        with serial_lock():
+            comports = serial_connection.available_comports()
+
+        if comports:
+            print(str(comports))
+            return jsonify(comports), 200
+        else:
+            return Response("No ports present.", 204)
+    except Exception as e:
+        return Response(str(e), 500)
+    
+@app.route("/comports/active")
+def active_comports():
+    port = ""
+    try:
+        with serial_lock():
+            port = serial_connection.get_port_name()
+
+        if not port:
+            return Response("No connection present.", 204)
+        else:
+            return Response(port, 200)
+    except Exception as e:
+        return Response(str(e), 500)
         
 @app.route("/connect", methods=["POST"])
 def connect():

--- a/app.py
+++ b/app.py
@@ -50,6 +50,8 @@ def comports():
         
 @app.route("/connect", methods=["POST"])
 def connect():
+    # Set up handling for request
+    connected = False
     data = request.get_json(silent=True)
     if not data: return "Missing POST JSON data"
 
@@ -63,17 +65,31 @@ def connect():
     except (TypeError, ValueError):
         return "Invalid timeout value"
     
-    try:
-        serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
+    # Check for an existing connection
+    if serial_connection.target is not None:
+        connected = True
+    
+    # Initialize a new connection if one does not exist
+    if not connected:
+        try:
+            with serial_lock():
+                serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
 
-        if not serial_connection.open_comport(): return "Failed to open comport"
+                if not serial_connection.open_comport(): return "Failed to open comport"
 
-        # send connect opcode
-        serial_connection.connect()
+                # send connect opcode
+                serial_connection.connect()
 
-        if( serial_connection.target is None ):
-            return Response("Serial connection failed.", status=400)
-
+                if( serial_connection.target is None ):
+                    return Response("Serial connection failed.", status=400)
+                else:
+                    connected = True
+        
+        except SerialException as e:
+            return Response("Serial connection error", status=400)
+    
+    # Return connection status
+    if connected and serial_connection.target is not None:
         return jsonify({
             "controller": {
                 "firmware": serial_connection.target.firmware.name,
@@ -81,14 +97,14 @@ def connect():
             },
             "status": "connected"
         })
-    
-    except SerialException as e:
-        return Response("Serial connection error", status=400)
+    else: # Shouldn't get here -- protective case
+        return Response("Serial connection failed (server-side error).", status=500)
     
 @app.route("/disconnect")
 def disconnect():
-    if not serial_connection.close_comport(): return "Failed to close comport"
-    return "Disconnected"
+    with serial_lock():
+        if not serial_connection.close_comport(): return "Failed to close comport"
+        return "Disconnected"
 
 # Stub, will be implemented for SDEC v2.1.0
 @app.route("/wireless-stats")

--- a/app.py
+++ b/app.py
@@ -53,26 +53,25 @@ def connect():
     # Set up handling for request
     connected = False
     data = request.get_json(silent=True)
-    if not data: return "Missing POST JSON data"
+    if not data: return Response("Missing POST JSON data", status=400)
 
     name = data.get("comport")
     timeout = data.get("timeout", 5)
 
-    if not name: return "Missing 'comport' field"
+    if not name: return Response("Missing 'comport' field", status=400)
 
     try:
         timeout = int(timeout)
     except (TypeError, ValueError):
-        return "Invalid timeout value"
-    
-    # Check for an existing connection
-    if serial_connection.target is not None:
-        connected = True
+        return Response("Invalid timeout value", status=400)
     
     # Initialize a new connection if one does not exist
-    if not connected:
-        try:
-            with serial_lock():
+    try:
+        with serial_lock():
+            # This check can cause a race condition. It needs to be in the lock.
+            if serial_connection.target is not None:
+                connected = True
+            else:
                 serial_connection.init_comport(name=name, baudrate=921600, timeout=timeout)
 
                 if not serial_connection.open_comport(): return "Failed to open comport"
@@ -84,9 +83,8 @@ def connect():
                     return Response("Serial connection failed.", status=400)
                 else:
                     connected = True
-        
-        except SerialException as e:
-            return Response("Serial connection error", status=400)
+    except SerialException as e:
+        return Response("Serial connection error", status=400)
     
     # Return connection status
     if connected and serial_connection.target is not None:
@@ -133,7 +131,13 @@ def dashboard_dump():
             if dashboard_dump_thread.is_alive(): # Protective case
                 return Response("Polling was already running", status=200)
             else:
+                global dashboard_dump_thread
                 stop_event.clear()
+                dashboard_dump_thread = threading.Thread(
+                    target=poll_dashboard_dump,
+                    args=(serial_connection, stop_event, telemetry_obj),
+                    daemon=True
+                )
                 dashboard_dump_thread.start()
                 return Response("Dashboard-dump poll started", status=200)
         elif stop:

--- a/hardware.py
+++ b/hardware.py
@@ -14,6 +14,7 @@ from SDECv2 import create_sensors
 
 # Serial connection lock
 _serial_lock = threading.Lock()
+_background_lifecycle_lock = threading.Lock()
 
 # APPA Firmware
 firmware = Firmware(
@@ -33,3 +34,6 @@ serial_connection = SerialObj()
 
 def serial_lock():
     return _serial_lock
+
+def background_lifecycle_lock():
+    return _background_lifecycle_lock


### PR DESCRIPTION
In order to let me test related features, #15 has been merged here as a staging branch.

Features:
- GET /comports now returns a json that includes the port name and a string description of that port. This makes it easier to pick out which device you actually want from the list if you don't have your flight computer comport memorized.
- GET /comports/active now returns a string containing the active comport of that SDEC-API instance. This allows clients to determine if another dashboard is already connected on a port, and will make multi-client operation easier (see: #15).

Children:
- SDEC (library): https://github.com/SunDevilRocketry/SDECv2/pull/73
- SDEC-CLI: https://github.com/SunDevilRocketry/SDEC-CLI/pull/16
- Dashboard (reference implementation): https://github.com/SunDevilRocketry/Flight-Software-GUI/pull/104

For proof of testing, see the CLI and dashboard child issues.