### PR TITLE
Add endpoints for preset upload/download

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 
 import atexit
 import threading
+import json
 
 from flask import Flask, request, Response, jsonify
 from flask_cors import CORS
@@ -19,7 +20,7 @@ from SDECv2 import SerialObj
 # Sensor
 from SDECv2 import SensorSentry
 # Parser
-from SDECv2 import Telemetry
+from SDECv2 import Telemetry, Parser, create_configs
 # Sensor utility
 from SDECv2 import create_sensors
 
@@ -156,6 +157,41 @@ def sensor_poll():
                     yield f"{sensor.name}: {val:.2f} {sensor.unit}"
 
     return Response(do_poll(), mimetype="text/plain")
+
+@app.route("/preset", methods=["GET", "POST"])
+def preset():
+    if serial_connection.target.controller.id != b"\x05": # Check if FC
+            return Response("The device is not a flight computer!", 400)
+    try:
+        if request.method == "GET": # DOWNLOAD
+            with serial_lock():
+                appa_preset_config = create_configs.appa_preset_config()
+                appa_parser = Parser(
+                    preset_config=appa_preset_config,
+                    preset_data=None
+                )
+                appa_parser.download_preset(serial_connection, path="SDECv2/a_output/temp_download.json")
+                downloaded_preset = json.load("SDECv2/a_output/temp_download.json")
+                return Response(downloaded_preset, 200)
+        
+        elif request.method == "POST": # UPLOAD
+            with serial_lock():
+                content = request.json
+
+                if not content:
+                    return Response("You must POST a json.", 400)
+                
+                appa_preset_config = create_configs.appa_preset_config()
+                appa_parser = Parser(
+                    preset_config=appa_preset_config,
+                    preset_data=None
+                )
+                json.dump("SDECv2/a_input/temp_upload.json")
+                appa_parser.upload_preset(serial_connection, path="SDECv2/a_input/temp_upload.json")
+        
+        return Response("Invalid Method", 400)
+    except Exception as e:
+        return Response(str(e), 500)
 
 @app.route("/")
 def default():

--- a/app.py
+++ b/app.py
@@ -171,25 +171,28 @@ def preset():
                     preset_data=None
                 )
                 appa_parser.download_preset(serial_connection, path="SDECv2/a_output/temp_download.json")
-                downloaded_preset = json.load("SDECv2/a_output/temp_download.json")
-                return Response(downloaded_preset, 200)
+                with open("SDECv2/a_output/temp_download.json", "r") as f:
+                    downloaded_preset = json.load(f)
+                return Response(json.dumps(downloaded_preset, sort_keys=False), 200, mimetype="application/json")
         
         elif request.method == "POST": # UPLOAD
+            content = json.loads(request.data.decode("utf-8"))
+            if not content:
+                return Response("You must POST a json.", 400)
+            
             with serial_lock():
-                content = request.json
-
-                if not content:
-                    return Response("You must POST a json.", 400)
                 
                 appa_preset_config = create_configs.appa_preset_config()
                 appa_parser = Parser(
                     preset_config=appa_preset_config,
                     preset_data=None
                 )
-                json.dump("SDECv2/a_input/temp_upload.json")
+                with open("SDECv2/a_input/temp_upload.json", "w") as f:
+                    json.dump(content, f)
                 appa_parser.upload_preset(serial_connection, path="SDECv2/a_input/temp_upload.json")
-        
-        return Response("Invalid Method", 400)
+
+                return Response("Successful upload!", 200)
+
     except Exception as e:
         return Response(str(e), 500)
 

--- a/app.py
+++ b/app.py
@@ -160,8 +160,11 @@ def sensor_poll():
 
 @app.route("/preset", methods=["GET", "POST"])
 def preset():
-    if serial_connection.target.controller.id != b"\x05": # Check if FC
-            return Response("The device is not a flight computer!", 400)
+    if serial_connection.target is None:
+        return Response("No device connected!", 400)
+    elif serial_connection.target.controller.id != b"\x05": # Check if FC
+        return Response("The device is not a flight computer!", 400)
+
     try:
         if request.method == "GET": # DOWNLOAD
             with serial_lock():


### PR DESCRIPTION
Both of these endpoints check out the serial lock for a very long time, but this only works over USB so we'll be fine. Definitely shouldn't be used for performance critical applications.

Closes #17. Unblocks https://github.com/SunDevilRocketry/Flight-Software-GUI/issues/16.

Test artifacts:

This is the return from the GET endpoint. We save off a temporary file because the library expects to output directly to a file.
[temp_download.json](https://github.com/user-attachments/files/28936405/temp_download.json)

This is what was sent back to the POST endpoint:
[temp_upload.json](https://github.com/user-attachments/files/28936413/temp_upload.json)

This is what was downloaded off the FC after this exchange:
[downloaded_preset.json](https://github.com/user-attachments/files/28936420/downloaded_preset.json)


