### PR TITLE
API: Server-Side Event Stream

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ from flask_cors import CORS
 from hardware import serial_connection, sensor_sentry, serial_lock, background_lifecycle_lock, firmware # Objects from hardware.py
 from serial import SerialException
 from stream import Stream
-from threads import poll_dashboard_dump, sse_stream_callback
+from threads import poll_dashboard_dump
 from typing import List, Dict
 from util import make_safe_number
 
@@ -174,7 +174,7 @@ def stream():
         not require upversioning.
     """
     return Response(
-        stream_with_context(stream_obj.sse_broadcast_callback),
+        stream_with_context(stream_obj.sse_broadcast_callback()),
         mimetype="text/event-stream"
     )
     

--- a/app.py
+++ b/app.py
@@ -175,7 +175,12 @@ def stream():
     """
     return Response(
         stream_with_context(stream_obj.sse_broadcast_callback()),
-        mimetype="text/event-stream"
+        mimetype="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no"
+        }
     )
     
 @app.route("/dashboard-dump", methods=["GET", "POST"])

--- a/app.py
+++ b/app.py
@@ -5,11 +5,12 @@ import atexit
 import threading
 import json
 
-from flask import Flask, request, Response, jsonify
+from flask import Flask, request, Response, jsonify, stream_with_context
 from flask_cors import CORS
 from hardware import serial_connection, sensor_sentry, serial_lock, background_lifecycle_lock, firmware # Objects from hardware.py
 from serial import SerialException
-from threads import poll_dashboard_dump
+from stream import Stream
+from threads import poll_dashboard_dump, sse_stream_callback
 from typing import List, Dict
 from util import make_safe_number
 
@@ -29,7 +30,9 @@ CORS(app)
 
 # Globals for polling dashboard dump
 stop_event = threading.Event()
+stream_obj = Stream()
 telemetry_obj = Telemetry()
+telemetry_obj.register_rx_callback(stream_obj.sse_put_callback)
 dashboard_dump_thread = threading.Thread(
     target=poll_dashboard_dump,
     args=(serial_connection, stop_event, telemetry_obj),
@@ -149,6 +152,31 @@ def wireless_stats():
         return telemetry_obj.get_latest_wireless_stats()
     else:
         return Response("No wireless target available.", status=204)
+    
+@app.route("/stream", methods=["GET"])
+def stream():
+    """
+    Subscribes to a server-sent event stream that is populated by all 
+    incoming messages.
+
+    Works for both the serial (USB) and over-the-air (LoRa) paths.
+
+    Integration Concerns: 
+        SDEC-API <-> SDEC - App initialization needs to provide a 
+        message_received callback to the telemetry object. SDEC needs
+        to invoke this callback upon receiving a new message. Null
+        or uninitialized callbacks must be handled.
+
+        SDEC-API <-> Client - Dashboard Dump must be initialized with
+        a POST request prior to subscribing to the stream, else no events
+        will be sent. The version number shall be incremented every time
+        an **existing** message type is changed. New message types do
+        not require upversioning.
+    """
+    return Response(
+        stream_with_context(stream_obj.sse_broadcast_callback),
+        mimetype="text/event-stream"
+    )
     
 @app.route("/dashboard-dump", methods=["GET", "POST"])
 def dashboard_dump():

--- a/stream.py
+++ b/stream.py
@@ -13,9 +13,8 @@ STREAM_VERSION_STRING = "1.0"
 
 
 class Stream:
-    def __init__(self):
-        self.signal_broadcast_event = threading.Event()
-        self.stream_mutex = threading.Lock()
+    def __init__(self) -> None:
+        self.stream_cond = threading.Condition()
         self.sequence_number = 0
         self.terminate = False
         self.data = None
@@ -24,7 +23,7 @@ class Stream:
         """
         Set up a message for all clients to broadcast.
         """
-        with self.stream_mutex:
+        with self.stream_cond:
             response = {
                 "origin": ORIGIN_STRING,
                 "version": STREAM_VERSION_STRING,
@@ -32,10 +31,9 @@ class Stream:
                 "messageType": messageType,
                 "payload": msg
             }
-            self.data = str("data: " + str(response) + "\n\n").encode("utf-8")
+            self.data = f"data: {json.dumps(response)}\n\n".encode("utf-8")
             self.sequence_number += 1
-        self.signal_broadcast_event.set() # Only signal the events after releasing the mutex
-        self.signal_broadcast_event.clear()
+            self.stream_cond.notify_all()
 
 
     def sse_broadcast_callback(self):
@@ -45,15 +43,25 @@ class Stream:
         last_seq_num = 0 # scoped to this instance
         
         # Send a message immediately on connect if one exists
-        with self.stream_mutex:
+        with self.stream_cond:
             if self.data is not None:
                 last_seq_num = self.sequence_number
-                yield self.data
+                data_to_yield = self.data
+            else:
+                data_to_yield = None
+                
+        if data_to_yield is not None:
+            yield data_to_yield
 
         # Wait for new messages to be put
         while not self.terminate:
-            self.signal_broadcast_event.wait()
-            with self.stream_mutex:
-                if self.data is not None and self.sequence_number != last_seq_num:
-                    last_seq_num = self.sequence_number
-                    yield self.data
+            with self.stream_cond:
+                # Wait for sequence_number to change to avoid spurious wakeups
+                while self.sequence_number == last_seq_num and not self.terminate:
+                    self.stream_cond.wait()
+                if self.terminate:
+                    break
+                last_seq_num = self.sequence_number
+                data_to_yield = self.data
+            
+            yield data_to_yield

--- a/stream.py
+++ b/stream.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Sun Devil Rocketry
+
+import threading
+import time
+
+from typing import Dict, Any
+from util import make_safe_number
+
+# CONSTANTS
+ORIGIN_STRING = "SDEC-API"
+STREAM_VERSION_STRING = "1.0"
+
+
+class Stream:
+    def __init__(self):
+        self.signal_broadcast_event = threading.Event()
+        self.stream_mutex = threading.Lock()
+        self.sequence_number = 0
+        self.terminate = False
+        self.data = None
+
+    def sse_put_callback(self, messageType: str, timestamp: float, msg: dict[str, Any]):
+        """
+        Set up a message for all clients to broadcast.
+        """
+        with self.stream_mutex:
+            self.data = {
+                "origin": ORIGIN_STRING,
+                "version": STREAM_VERSION_STRING,
+                "timestamp": timestamp,
+                "messageType": messageType,
+                "payload": msg
+            }
+            self.sequence_number += 1
+        self.signal_broadcast_event() # Only signal the events after releasing the mutex
+
+
+    def sse_broadcast_callback(self):
+        """
+        Yields messages for the client with this request open.
+        """
+        last_seq_num = 0 # scoped to this instance
+        
+        # Send a message immediately on connect if one exists
+        with self.stream_mutex:
+            if self.data is not None:
+                last_seq_num = self.sequence_number
+                yield self.data
+
+        # Wait for new messages to be put
+        while not self.terminate:
+            self.signal_broadcast_event.wait()
+            with self.stream_mutex:
+                if self.data is not None and self.sequence_number != last_seq_num:
+                    last_seq_num = self.sequence_number
+                    yield self.data

--- a/stream.py
+++ b/stream.py
@@ -3,6 +3,7 @@
 
 import threading
 import time
+import json
 
 from typing import Dict, Any
 from util import make_safe_number
@@ -10,6 +11,8 @@ from util import make_safe_number
 # CONSTANTS
 ORIGIN_STRING = "SDEC-API"
 STREAM_VERSION_STRING = "1.0"
+RATE_LIMITER_HZ = 30
+RATE_LIMITER_PERIOD = 1.0 / RATE_LIMITER_HZ
 
 
 class Stream:
@@ -23,6 +26,7 @@ class Stream:
         """
         Set up a message for all clients to broadcast.
         """
+
         with self.stream_cond:
             response = {
                 "origin": ORIGIN_STRING,
@@ -41,6 +45,7 @@ class Stream:
         Yields messages for the client with this request open.
         """
         last_seq_num = 0 # scoped to this instance
+        last_time = 0
         
         # Send a message immediately on connect if one exists
         with self.stream_cond:
@@ -59,6 +64,16 @@ class Stream:
                 # Wait for sequence_number to change to avoid spurious wakeups
                 while self.sequence_number == last_seq_num and not self.terminate:
                     self.stream_cond.wait()
+                # delay the broadcast (yielding to other threads) if rate limiter
+                # indicates that messages are coming in too fast
+                curr_time = time.time()
+                if RATE_LIMITER_PERIOD + last_time < curr_time:
+                    # Release the lock if we have to wait for the timeout,
+                    # then reacquire once we're back on the target rate.
+                    self.stream_cond.release()
+                    time.sleep( RATE_LIMITER_PERIOD + last_time - curr_time )
+                    self.stream_cond.acquire()
+                # end the broadcast entirely if the termination flag is
                 if self.terminate:
                     break
                 last_seq_num = self.sequence_number

--- a/stream.py
+++ b/stream.py
@@ -25,15 +25,17 @@ class Stream:
         Set up a message for all clients to broadcast.
         """
         with self.stream_mutex:
-            self.data = {
+            response = {
                 "origin": ORIGIN_STRING,
                 "version": STREAM_VERSION_STRING,
                 "timestamp": timestamp,
                 "messageType": messageType,
                 "payload": msg
             }
+            self.data = str("data: " + str(response) + "\n\n").encode("utf-8")
             self.sequence_number += 1
-        self.signal_broadcast_event() # Only signal the events after releasing the mutex
+        self.signal_broadcast_event.set() # Only signal the events after releasing the mutex
+        self.signal_broadcast_event.clear()
 
 
     def sse_broadcast_callback(self):

--- a/stream.py
+++ b/stream.py
@@ -45,7 +45,7 @@ class Stream:
         Yields messages for the client with this request open.
         """
         last_seq_num = 0 # scoped to this instance
-        last_time = 0
+        last_time = time.monotonic()
         
         # Send a message immediately on connect if one exists
         with self.stream_cond:
@@ -66,17 +66,20 @@ class Stream:
                     self.stream_cond.wait()
                 # delay the broadcast (yielding to other threads) if rate limiter
                 # indicates that messages are coming in too fast
-                curr_time = time.time()
-                if RATE_LIMITER_PERIOD + last_time < curr_time:
+                curr_time = time.monotonic()
+                if curr_time < RATE_LIMITER_PERIOD + last_time:
                     # Release the lock if we have to wait for the timeout,
                     # then reacquire once we're back on the target rate.
                     self.stream_cond.release()
-                    time.sleep( RATE_LIMITER_PERIOD + last_time - curr_time )
-                    self.stream_cond.acquire()
-                # end the broadcast entirely if the termination flag is
+                    try:
+                        time.sleep( RATE_LIMITER_PERIOD + last_time - curr_time )
+                    finally:
+                        self.stream_cond.acquire()
+                # end the broadcast entirely if the termination flag is set
                 if self.terminate:
                     break
                 last_seq_num = self.sequence_number
                 data_to_yield = self.data
+                last_time = time.monotonic()
             
             yield data_to_yield


### PR DESCRIPTION
Closes: #23 

Adds a method to broadcast received messages to all connected clients rather than requiring polling.

Preliminary performance testing does indicate slightly worse performance than the polling implementation. We should determine the cause of this. This performance hit does not affect the API as long as no SSE clients are connected though.

Library Side: https://github.com/SunDevilRocketry/SDECv2/pull/76

Merge is dependent on the state-estims-telemetry integration branch.